### PR TITLE
Fix/#4 main page views not update

### DIFF
--- a/src/components/blog-main/context.tsx
+++ b/src/components/blog-main/context.tsx
@@ -1,0 +1,23 @@
+import { type Dispatch, type SetStateAction, createContext, useContext } from 'react';
+
+import { APIStatusType } from '@/api/views/type';
+import { Post } from '@/types/post';
+
+type PostsContextType = {
+  allPosts: Post[];
+  displayPosts: Post[];
+  setDisplayPosts: Dispatch<SetStateAction<Post[]>>;
+  apiStatus: APIStatusType;
+};
+
+const PostsContext = createContext<PostsContextType | undefined>(undefined);
+
+export default PostsContext;
+
+export const usePostsContext = () => {
+  const value = useContext(PostsContext);
+
+  if (!value) throw new Error('usePostsContext 는 PostsContext 내부에서 사용되어야 합니다.');
+
+  return value;
+};

--- a/src/components/blog-main/index.tsx
+++ b/src/components/blog-main/index.tsx
@@ -1,22 +1,34 @@
+import { useState } from 'react';
+
 import { PageSEO } from '@/components/SEO';
+import PostsContext from '@/components/blog-main/context';
 import Greeting from '@/components/blog-main/greeting';
 import PostList from '@/components/blog-main/post-list';
+import TagFilter from '@/components/blog-main/tag-filter';
 import * as Layout from '@/components/layout';
 import { Post } from '@/types/post';
+
+import type { APIStatusType } from '@/api/views/type';
 
 export type BlogMainProps = {
   posts: Post[];
   tags: string[];
 };
 
-const BlogMain = (props: BlogMainProps) => {
+const BlogMain = (props: BlogMainProps & { apiStatus: APIStatusType }) => {
+  const { posts: allPosts, apiStatus } = props;
+  const [displayPosts, setDisplayPosts] = useState(allPosts);
+
   return (
     <>
       <PageSEO />
 
       <Layout.Box padding='0 10px' margin='0 0 100px 0' width='92%'>
         <Greeting />
-        <PostList {...props} />
+        <PostsContext.Provider value={{ allPosts, displayPosts, setDisplayPosts, apiStatus }}>
+          <TagFilter tags={props.tags} />
+          <PostList />
+        </PostsContext.Provider>
       </Layout.Box>
     </>
   );

--- a/src/components/blog-main/post-list.tsx
+++ b/src/components/blog-main/post-list.tsx
@@ -1,57 +1,36 @@
 import { AnimatePresence, motion } from 'framer-motion';
 
-import TagFilter from '@/components/blog-main/tag-fliter';
+import { usePostsContext } from '@/components/blog-main/context';
 import * as Layout from '@/components/layout';
 import PostPreview from '@/components/post-preview';
 import PostPreviewSkeleton from '@/components/post-preview/skeleton';
-import { fadeIn, staggerHalf } from '@/lib/animations';
-import useCombinedPost from '@/lib/hooks/use-combined-post';
-import useFilteredPost from '@/lib/hooks/use-filtered-post';
+import { staggerHalf } from '@/lib/animations';
 
-import type { BlogMainProps } from '@/components/blog-main';
-
-const PostList = ({ posts: initialPost, tags }: BlogMainProps) => {
-  const { posts, status: postStatus } = useCombinedPost(initialPost);
-  const { filteredPosts, selectedTag, setTag } = useFilteredPost(posts, 'ALL');
-
-  const handleTagFilter = (tagName: string | 'ALL') => {
-    setTag(tagName);
-  };
+const PostList = () => {
+  const { displayPosts, apiStatus: postApiStatus } = usePostsContext();
 
   return (
-    <>
-      <motion.section variants={fadeIn} initial='initial' animate='animate'>
-        <Layout.HStack margin='0 0 15px 0' gap='10px'>
-          <TagFilter onSelect={handleTagFilter} tags={tags} selectedTag={selectedTag} />
-        </Layout.HStack>
-      </motion.section>
-
-      <motion.section variants={staggerHalf} initial='initial' animate='animate'>
-        <motion.div variants={staggerHalf}>
-          <Layout.VStack gap='20px'>
-            <AnimatePresence>
-              {(postStatus.isLoading || postStatus.isAbort) && (
-                <motion.div
-                  initial={{ opacity: 0.8 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                >
-                  <Layout.VStack width='100%' gap='20px'>
-                    <PostPreviewSkeleton />
-                    <PostPreviewSkeleton />
-                    <PostPreviewSkeleton />
-                  </Layout.VStack>
-                </motion.div>
-              )}
-              {(postStatus.isSuccess || postStatus.isError) &&
-                filteredPosts.map((post) => (
-                  <PostPreview key={crypto.randomUUID()} post={post} viewStatus={postStatus} />
-                ))}
-            </AnimatePresence>
-          </Layout.VStack>
-        </motion.div>
-      </motion.section>
-    </>
+    <motion.section variants={staggerHalf} initial='initial' animate='animate'>
+      <motion.div variants={staggerHalf}>
+        <Layout.VStack gap='20px'>
+          <AnimatePresence>
+            {(postApiStatus.isLoading || postApiStatus.isAbort) && (
+              <motion.div initial={{ opacity: 0.8 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+                <Layout.VStack width='100%' gap='20px'>
+                  <PostPreviewSkeleton />
+                  <PostPreviewSkeleton />
+                  <PostPreviewSkeleton />
+                </Layout.VStack>
+              </motion.div>
+            )}
+            {(postApiStatus.isSuccess || postApiStatus.isError) &&
+              displayPosts.map((post) => (
+                <PostPreview key={crypto.randomUUID()} post={post} viewStatus={postApiStatus} />
+              ))}
+          </AnimatePresence>
+        </Layout.VStack>
+      </motion.div>
+    </motion.section>
   );
 };
 

--- a/src/components/blog-main/tag-filter.tsx
+++ b/src/components/blog-main/tag-filter.tsx
@@ -1,0 +1,24 @@
+import { motion } from 'framer-motion';
+
+import TagFilter from '@/components/blog-main/tag-fliter';
+import * as Layout from '@/components/layout';
+import { fadeIn } from '@/lib/animations';
+import useFilteredPost from '@/lib/hooks/use-filtered-post';
+
+const TagFilterContainer = ({ tags }: { tags: string[] }) => {
+  const { setTag, selectedTag } = useFilteredPost('ALL');
+
+  const handleTagFilter = (tagName: string | 'ALL') => {
+    setTag(tagName);
+  };
+
+  return (
+    <motion.section variants={fadeIn} initial='initial' animate='animate'>
+      <Layout.HStack margin='0 0 15px 0' gap='10px'>
+        <TagFilter onSelect={handleTagFilter} tags={tags} selectedTag={selectedTag} />
+      </Layout.HStack>
+    </motion.section>
+  );
+};
+
+export default TagFilterContainer;

--- a/src/components/blog-main/utils.ts
+++ b/src/components/blog-main/utils.ts
@@ -10,6 +10,6 @@ export function updateViewFromServerPost(clientPosts: Post[], serverPostInfos: S
       .filter((serverPost) => serverPost.id === clientPost.uuid)
       .pop();
 
-    return { ...clientPost, view: Number(updatedPost?.views) || clientPost.view };
+    return { ...clientPost, views: Number(updatedPost?.views) || 0 };
   });
 }

--- a/src/components/blog-post/post-info/index.tsx
+++ b/src/components/blog-post/post-info/index.tsx
@@ -11,7 +11,7 @@ const PCViewPostInfo = dynamic(() => import('@/components/blog-post/post-info/pc
 
 const PostInfo = ({ post, tag }: { post: Post; tag: string }) => {
   const { windowSize } = useWindowSize();
-  const { views, status: viewsApiStatus } = useUpdateViews({ uuid: post.uuid, view: post.view });
+  const { views, status: viewsApiStatus } = useUpdateViews({ uuid: post.uuid, views: post.views });
 
   return (
     <>

--- a/src/components/post-preview/index.tsx
+++ b/src/components/post-preview/index.tsx
@@ -36,7 +36,7 @@ const PostPreview = ({ post, viewStatus }: { post: Post; viewStatus: APIStatusTy
                 <Layout.HStack gap='10px' alignItems='center'>
                   <Style.InfoP suppressHydrationWarning>{post.formattedDate}</Style.InfoP>
                   <Style.InfoP>{`${post.readingTime} min`}</Style.InfoP>
-                  {viewStatus.isSuccess && <Style.InfoP>{`${post.view} views`}</Style.InfoP>}
+                  {viewStatus.isSuccess && <Style.InfoP>{`${post.views} views`}</Style.InfoP>}
                 </Layout.HStack>
               </Layout.HStack>
             </Layout.VStack>

--- a/src/constants/blogDataset.ts
+++ b/src/constants/blogDataset.ts
@@ -44,23 +44,7 @@ export class StaticPostData {
       StaticPostData.instance = new StaticPostData();
     }
 
-    await StaticPostData.instance.updatePostViewsFromServer();
+    StaticPostData.instance.serverPosts = await getBlogPost();
     return StaticPostData.instance;
-  }
-
-  /**
-   * @description 각 포스트의 조회수 서버 데이터를 불러와 클라이언트 포스트 데이터에 추가하는 함수.
-   */
-  private async updatePostViewsFromServer() {
-    this.serverPosts = await getBlogPost();
-
-    if (this.serverPosts.length > 0) {
-      this.posts = this.posts.map((post) => {
-        const addViewPost: Post = { ...post, view: 0 };
-        addViewPost.view =
-          this.serverPosts.find((serverPosts) => post.uuid === serverPosts.id)?.view ?? 0;
-        return addViewPost;
-      });
-    }
   }
 }

--- a/src/constants/utils.ts
+++ b/src/constants/utils.ts
@@ -9,6 +9,6 @@ export function initializePost(post: ContentlayerPost): Post {
     ...post,
     tag,
     uuid: post.uuid.replace(/\n|\r|\s*/g, ''),
-    view: 0,
+    views: 0,
   };
 }

--- a/src/lib/hooks/use-combined-post.ts
+++ b/src/lib/hooks/use-combined-post.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 
 import axios from 'axios';
 
@@ -10,7 +10,7 @@ import type { Post } from '@/types/post';
 
 /**
  *  서버 데이터와 클라이언트 데이터를 합치는 커스텀 훅
- * @returns {object} { posts : 서버 데이터 추가가 완료된 post 객체 , status : 서버 데이터 패칭 상태를 나타내는 변수 }
+ * @returns {object} { posts : 서버 데이터 추가가 완료된 post 객체 , status : 서버 데이터 패칭 상태를 나타내는 변수, key: 재 랜더링 트리거 알림 변수 }
  */
 const useCombinedPost = (initialPost: Post[]) => {
   const [posts, setPosts] = useState(initialPost);
@@ -18,6 +18,8 @@ const useCombinedPost = (initialPost: Post[]) => {
     ...initialApiStatus,
     isLoading: true,
   });
+
+  const key = crypto.randomUUID();
 
   useEffect(() => {
     const CancelToken = axios.CancelToken;
@@ -40,7 +42,7 @@ const useCombinedPost = (initialPost: Post[]) => {
     };
   }, []);
 
-  return { posts, status: viewStatus };
+  return { posts, status: viewStatus, key };
 };
 
 export default useCombinedPost;

--- a/src/lib/hooks/use-filtered-post.ts
+++ b/src/lib/hooks/use-filtered-post.ts
@@ -1,22 +1,25 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-import type { Post } from '@/types/post';
+import { usePostsContext } from '@/components/blog-main/context';
 
-const useFilteredPost = (initialPosts: Post[], initialTag: string) => {
-  const [filteredPosts, setFilteredPosts] = useState(initialPosts);
+const useFilteredPost = (initialTag: string) => {
+  const { setDisplayPosts, allPosts } = usePostsContext();
   const [selectedTag, setSelectedTag] = useState(initialTag);
 
-  const setTag = useCallback((tag: string) => {
-    if (tag === initialTag) {
-      setFilteredPosts(initialPosts);
-    } else {
-      setFilteredPosts(initialPosts.filter((post) => post.url.includes(tag)));
-    }
+  const setTag = useCallback(
+    (tag: string) => {
+      if (tag === initialTag) {
+        setDisplayPosts(allPosts);
+      } else {
+        setDisplayPosts(allPosts.filter((post) => post.url.includes(tag)));
+      }
 
-    setSelectedTag(tag);
-  }, []);
+      setSelectedTag(tag);
+    },
+    [allPosts, initialTag],
+  );
 
-  return { setTag, filteredPosts, selectedTag };
+  return { setTag, selectedTag };
 };
 
 export default useFilteredPost;

--- a/src/lib/hooks/use-update-views.ts
+++ b/src/lib/hooks/use-update-views.ts
@@ -7,7 +7,7 @@ import { isError, type APIStatusType, initialApiStatus } from '@/api/views/type'
 
 import type { Post } from '@/types/post';
 
-export default function useUpdateViews({ uuid, view: initialView }: Pick<Post, 'uuid' | 'view'>) {
+export default function useUpdateViews({ uuid, views: initialView }: Pick<Post, 'uuid' | 'views'>) {
   const [views, setView] = useState(initialView);
   const [apiStatus, setApiStatus] = useState<APIStatusType>({
     ...initialApiStatus,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,12 +2,15 @@ import { GetStaticProps, InferGetStaticPropsType } from 'next';
 
 import BlogMain from '@/components/blog-main';
 import { StaticPostData } from '@/constants/blogDataset';
+import useCombinedPost from '@/lib/hooks/use-combined-post';
 import { handlePostDataServerUpdate } from '@/utils/db-utils';
 
 import type { Post } from '@/types/post';
 
 export default function Home(props: InferGetStaticPropsType<typeof getStaticProps>) {
-  return <BlogMain {...props} />;
+  const { posts, status: apiStatus, key } = useCombinedPost(props.posts);
+
+  return <BlogMain {...{ ...props, posts, apiStatus }} key={key} />;
 }
 
 export const getStaticProps = (async () => {

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,3 +1,3 @@
 import { type Post as ContentlayerPost } from 'contentlayer/generated';
 
-export type Post = ContentlayerPost & { tag: string; view: number };
+export type Post = ContentlayerPost & { tag: string; views: number };


### PR DESCRIPTION
### 변경 사항
- [x] `useCombinedPost` 훅에 랜덤 key 생성 및 반환하도록 구성.
   - `key` : 해당 훅의 데이터(서버 + 클라 데이터 합쳐진 포스트) 가 업데이트 되었음을 알려주는 변수
   - useState의 초깃값은 처음 랜더링 이후 무시되기 때문에 상위 컴포넌트의 key 값을 바꾸어 재 랜더링이 되었음을 알려주도록 구성

- [x] FilterTag 컴포넌트 분리, PostContext 적용
    - 기존 PageList 내부에 FilterTag 가 위치해 있어 테그와 관련된 핸들러와 상태 변수가 PageList에 혼재해 있었음.
    - 컴포넌트를 분리하며 PageList와 FilterTage가 서로 공유하는 상태만 Context를 통해 관리하도록 함